### PR TITLE
Remove fixed version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "mageplaza/module-core": "^1.3.13"
   },
   "type": "magento2-language",
-  "version": "1.0.1",
   "minimum-stability": "dev",
   "prefer-stable": true,
   "license": [


### PR DESCRIPTION
The version should be defined as a tag (git tag 1.0.1) afterwards, so I can automatically discover and add the module via "composer require mageplaza/magento-2-chinese-language-pack".

With a fixed version in composer.json this triggers the error "Could not find a version of package mageplaza/magento-2-chinese-language-pack matching your minimum-stability (stable). Require it with an explicit version constraint all owing its desired stability." in composer v1.8.5; so currently we have to fork the module or require dev-master to get it to work.